### PR TITLE
Allow Settings ScriptableObject to be placed in different folder structures

### DIFF
--- a/UPMPackage/Editor/ByteBrewSettingsHandler.cs
+++ b/UPMPackage/Editor/ByteBrewSettingsHandler.cs
@@ -21,8 +21,10 @@ public static class ByteBrewSettingsHandler
     {
         string bytebrewSettingsDirPath = Path.Combine("Assets", "ByteBrewSDK", "Resources");
         string bytebrewSettingsPath = Path.Combine(bytebrewSettingsDirPath, "ByteBrewSettings.asset");
-
-        ByteBrewSettings settings = AssetDatabase.LoadAssetAtPath<ByteBrewSettings>(bytebrewSettingsPath);
+        string[] assets = AssetDatabase.FindAssets($"t:{nameof(ByteBrewSettings)}");
+        string path = assets.Length > 0 ? AssetDatabase.GUIDToAssetPath(assets[0]) : bytebrewSettingsPath;
+        ByteBrewSettings settings = AssetDatabase.LoadAssetAtPath<ByteBrewSettings>(path);
+        
         if (settings != null) {
             return settings;
         }


### PR DESCRIPTION
Currently the package only allows Settings to live in the Assets/ByteBrew/Resources folder.
Some projects grow in scope and this tight structure can become a problem.

Added initial check on ByteBrewSettingsHandler during Settings ScriptableObject asset creation to see if the scriptable object is already present in the Unity project
This check also avoids running the entire logic if the settings already exist

## Changes
- Added dynamic asset discovery using AssetDatabase.FindAssets
- Implemented fallback to default path when no existing asset is found

## Testing
- Verified asset discovery works in Unity editor
- Confirmed fallback behavior when no asset exists